### PR TITLE
removes 'go back' button, unnecessary with navbar

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -26,9 +26,6 @@ export default function About() {
 			</main>
 			<footer className={styles.footer}>
 				<ol>
-					<li className={'text-lg text-center font-bold'}>
-						<a href={'/..'}> Go back </a>
-					</li>
 					<li className={'text-lg'}>
 						Created in part by Yves-Shaheem Shedid & Mathieu Gouveia Sousa.
 					</li>


### PR DESCRIPTION
Just removes the 'go back' button on the about page, that's all